### PR TITLE
[#870966] Webmaker.org: Flip border on makes

### DIFF
--- a/public/css/style.less
+++ b/public/css/style.less
@@ -78,7 +78,6 @@ a {
 }
 
 .make {
-  border-bottom: @make-border-size solid transparent;
   color: #FFF;
   position: relative;
   overflow: hidden;
@@ -126,7 +125,7 @@ a {
 .front,
 .back {
   .backface-visibility(hidden);
-  .border-top-radius;
+  .border-radius;
   bottom: 0;
   display: block;
   overflow: hidden;
@@ -201,6 +200,10 @@ h3 {
 
 .internal {
   border-bottom: @make-border-size solid #FF0B00;
+}
+
+.default {
+  border-bottom: @make-border-size solid #FFF;
 }
 
 p {

--- a/public/js/base/mediaGallery.js
+++ b/public/js/base/mediaGallery.js
@@ -81,27 +81,31 @@ define(['jquery'],
 
     switch ( data.tags.makeType ) {
       case 'popcorn':
-        $makeContainer.addClass( 'popcorn' );
+        $frontEl.addClass( 'popcorn' );
         break;
 
       case 'thimble':
-        $makeContainer.addClass( 'thimble' );
+        $frontEl.addClass( 'thimble' );
         break;
 
       case 'challenge':
-        $makeContainer.addClass( 'challenge' );
+        $frontEl.addClass( 'challenge' );
         break;
 
       case 'event':
-        $makeContainer.addClass( 'event' );
+        $frontEl.addClass( 'event' );
         break;
 
       case 'kit':
-        $makeContainer.addClass( 'kit' );
+        $frontEl.addClass( 'kit' );
         break;
 
       case 'demo':
-        $makeContainer.addClass( 'make-demo' );
+        $frontEl.addClass( 'make-demo' );
+        break;
+
+      default:
+        $frontEl.addClass( 'default' );
         break;
     }
 


### PR DESCRIPTION
- Now applying border to front of make so it disappears when the make card is 'flipped'.
- Adding a default case for make border types in JS. For now, applying 'popcorn' until tags are properly sorted out on the API side.
