### PR TITLE
Add support for overriding footer section in layout.html view.

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -65,7 +65,6 @@
 
   <main id="content" class="content clearfix">{% block body %}{% endblock %}</main>
 
-  {% block footer %}
   <footer class="footer">
     <div id="footer-actions">
       {% if page == 'index' or page == 'teach' %}
@@ -73,6 +72,7 @@
       {% endif %}
       <button id="bottom-search-btn">Back to top <span class="icon-angle-up"></span></button>
     </div>
+    {% block footer %}
     <section class="make-footer">
       <div class="c-leftarrow cta-arrow hide">
         <i class="icon-angle-left"></i>
@@ -84,6 +84,7 @@
         <i class="icon-angle-right"></i>
       </div>
     </section>
+    {% endblock %}
     <div class="partnerWrapper">
     <section class="partners">
       <span class="partners-header">
@@ -149,7 +150,6 @@
     </section>
   </div>
   </footer>
-  {% endblock %}
   <div class="mobile"></div>
 </div><!-- webmaker-outer-wrapper -->
 <script>


### PR DESCRIPTION
This is needed to resolve ticket #882847: "Remove CTA bar, replace with 'event guide' link" (https://bugzilla.mozilla.org/show_bug.cgi?id=882847), and blocks this pull request: https://github.com/mozilla/webmaker-events/pull/6
