### PR TITLE
bug886283 - correct email on /mentor page

### DIFF
--- a/views/mentor.html
+++ b/views/mentor.html
@@ -86,7 +86,7 @@
 	eager learners, not to mention filmmakers, journalists, politicians, artists and inventors.</li>
 	<li><strong>Get gear.</strong> Webmaker mentors get access to coveted Mozilla gear like stickers,
 	t-shirts and banners to excite learners and make events even more awesome.
-	<a href="mailto:markerparty@mozilla.org">Get in touch</a> to learn more.</li>
+	<a href="mailto:makerparty@mozilla.org">Get in touch</a> to learn more.</li>
 	<li><strong>Shape standards.</strong> A global community that wants to teach the web right
 	is creating a <a href="https://wiki.mozilla.org/Learning/WebLiteracyStandard">Web Literacy Standard</a>.
 	We're trying to build consensus around the skills, competencies and literacies necessary to read, write


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=886283
