### PR TITLE
Fix Bug 890323 - Tag search on /search separates on commas only. crash b...

### DIFF
--- a/routes/search.js
+++ b/routes/search.js
@@ -24,13 +24,11 @@ module.exports = function(req, res) {
   if ( type === 'tags' ) {
     var tags = query.split(',');
     options.tags = [];
-    if( tags.length === 1 ) { // try splitting with spaces, too
-      tags = query.split(' ');
-    }
     options.tags[0] = tags.map(function( t ) {
       // check for hashtag, remove
+      t = t.trim();
       if ( t[0] === '#' ) {
-        return tag.slice(1);
+        return t.slice(1);
       }
       return t;
     });


### PR DESCRIPTION
...ug fixed for tag searches containing '#' at the front of the string

https://bugzilla.mozilla.org/show_bug.cgi?id=890323
