### PR TITLE
bug899793 - removed a duplicate paragraph from /terms

### DIFF
--- a/views/terms.html
+++ b/views/terms.html
@@ -212,21 +212,6 @@
           including but not limited to out of your violation of any representation 
           or warranty contained in these Terms.</p>
 
-        <h2>Release and Indemnification</h2>
-        <p>You release Mozilla, its officers, employees, agents and successors 
-          from claims, demands and damages of every kind or nature arising out 
-          of or related to any disputes with other users, including with respect 
-          to any meetings you may wish to attend. You further waive any and all 
-          rights and benefits otherwise conferred by any statutory or non-statutory 
-          law of any jurisdiction that would purport to limit the scope of a release or waiver.</p>
-
-        <p>You agree to defend, indemnify and hold harmless Mozilla, its 
-          contractors and its licensors, and their respective directors, 
-          officers, employees and agents from and against any and all third 
-          party claims and expenses, including attorneys' fees, arising out 
-          of your use of Webmaker, including but not limited to out of your 
-          violation of any representation or warranty contained in these Terms.</p>
-
         <h2>Disclaimer; Limitation of Liability</h2>
         <p>EXCEPT AS OTHERWISE EXPRESSLY STATED, INCLUDING BUT NOT LIMITED TO 
           IN A LICENSE OR OTHER AGREEMENT GOVERNING THE USE OF SPECIFIC CONTENT, 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=899703
