### PR TITLE
Fix Bug 902043 - Don't strip the hashtag from tag search terms

### DIFF
--- a/routes/search.js
+++ b/routes/search.js
@@ -48,12 +48,7 @@ module.exports = function(req, res) {
     var tags = query.split(',');
     options.tags = [];
     options.tags[0] = tags.map(function( t ) {
-      // check for hashtag, remove
-      t = t.trim();
-      if ( t[0] === '#' ) {
-        return t.slice(1);
-      }
-      return t;
+      return t.trim();
     });
   } else {
     // check for '@', remove


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=902043
