### PR TITLE
Fix Bug 901975 - Update webmaker-events version to v0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "newrelic": "0.9.22",
     "nunjucks": "git://github.com/jlongster/nunjucks.git#0fc9622f3471d67058e431f765bc45d928d23a61",
     "sightmap": "0.0.1",
-    "webmaker-events": "https://github.com/mozilla/webmaker-events/tarball/v0.1.14",
+    "webmaker-events": "https://github.com/mozilla/webmaker-events/tarball/v0.1.15",
     "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.9"
   },
   "devDependencies": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=901975
