### PR TITLE
[bug 918492] Fix wrong link on /teach to mentor resources

### DIFF
--- a/locale/en_US/messages.json
+++ b/locale/en_US/messages.json
@@ -340,7 +340,7 @@
     "Teach the web paragraph": "You don’t need to be a wizard to teach the web. We've created <a href='/{{lang}}/teach'>hackable guides</a> for teaching digital literacy, webmaking, online storytelling and more.",
     "Teach the web": "Teach the web",
     "Teach": "Teach",
-    "teachBanner": "<strong>Join us! </strong><a href='https://mozteach.makes.org/thimble/how-to-become-a-webmaker-mentor'>Become a Mozilla Webmaker Mentor</a> and help learners around the world level up their skills. It’s all part of our <a href='http://webmaker.org/mentor'>non-profit mission</a> to spread web skills and digital creativity for all.",
+    "teachBanner": "<strong>Join us! </strong><a href='https://mozteach.makes.org/thimble/become-a-webmaker-mentor'>Become a Mozilla Webmaker Mentor</a> and help learners around the world level up their skills. It’s all part of our <a href='http://webmaker.org/mentor'>non-profit mission</a> to spread web skills and digital creativity for all.",
     "teachDesc": "<strong>We've got creative ways to help <em>anyone</em> teach <a href='https://wiki.mozilla.org/Learning/WebLiteracies'>web literacy</a>, digital skills and making</strong>. Use our free <a href='https://webmaker.org/tools'>tools</a>, activities and lesson plans. <a href='/teach-templates'>Or make your own</a> &ndash; with help from our <a href='https://plus.google.com/communities/106022863174952221205'>global community</a> of educators, techies and mentors like you.",
     "teachHeader": "Let's teach the web!<br>",
     "teachingkit": "Teaching Kit",


### PR DESCRIPTION
:shipit: 
