### PR TITLE
[bug 925353] Fix fuzzy partners text on /party on Firefox

### DIFF
--- a/public/css/style.less
+++ b/public/css/style.less
@@ -1108,6 +1108,7 @@ img {
           vertical-align: middle;
           font-size: 1.5em;
           text-decoration: none;
+          font-weight: normal;
           &:hover {
             text-decoration: underline;
           }


### PR DESCRIPTION
- This was a Firefox-only bug from what I can see. Adding this new CSS rule seems to fix it!
- :shipit: 
