### PR TITLE
Bug 901600 - Share button on details page - use twitter/g+ icons instead (?)

### DIFF
--- a/locale/en_US/webmaker.org.json
+++ b/locale/en_US/webmaker.org.json
@@ -428,6 +428,7 @@
   "Translate Webmaker": "Translate Webmaker",
   "Try the Goggles": "Try the Goggles now",
   "Tweet #teachtheweb": "Tweet #teachtheweb",
+  "TweetText":"Check this out: ",
   "Unnati": "Unnati",
   "Upcoming Events": "<em>Upcoming<br />Events</em>",
   "Updated at": "Updated at",

--- a/views/details.html
+++ b/views/details.html
@@ -62,9 +62,10 @@
                   <span class="make-relative-date">{{ createdAt }}</span>
                 </span>
               </div>
-
               <span class="social-media">
-                <a id="share-btn" class="share ui-btn"><span class="icon-share"></span> {{ gettext("Share") }}</a>
+              {% set tweetText = gettext("TweetText") %}
+                 <a href="https://plus.google.com/share?url={{url}}" id="share-gplus" target="_blank" class="btn"><span class="icon-google-plus icon">{{ gettext("Share") }}</span></a>
+                 <a id="share-twitter" href="https://twitter.com/intent/tweet?text={{tweetText }}{{url}}&hashtags=Webmaker&related=webmaker&url={{url}}" target="_blank" class="share btn"><span class="icon-twitter icon"> {{ gettext("Share") }}</span></a>
                 <span id="share-container" class="hidden">
                   <a target="_blank" id="google-btn"></a>
                   <a target="_blank" id="twitter-btn"></a>


### PR DESCRIPTION
Hi,

> > > I've added two buttons to enable users to tweet their make url's to twitter and by using twitter intent web services I've managed to allow them to tweet a message (see image below).

![twitterposting](https://f.cloud.github.com/assets/1269759/1345978/41dc7f6c-3699-11e3-8170-1d2b84de7888.png)

> > > I found a way to suggest that users follow webmaker twitter handle right after sending their message (see image below).

![twittersuggestsusertofollowwebmaker](https://f.cloud.github.com/assets/1269759/1345973/26491e40-3699-11e3-96e5-dd2d3d89d31a.png)
