### PR TITLE
Fix Bug 929229 - Make's should link to project page on mobile rather tha...

### DIFF
--- a/public/css/page-specific/teachtheweb.less
+++ b/public/css/page-specific/teachtheweb.less
@@ -23,6 +23,25 @@
   margin: 0 auto;
   position: relative;
   width: 100%;
+
+  .mobile-link {
+    display: block;
+  }
+
+  .desktop-link {
+    display: none;
+  }
+
+  @media screen and (min-device-width : @width-large) {
+    .mobile-link {
+      display: none;
+    }
+
+    .desktop-link {
+      display: block;
+    }
+  }
+
   @media (min-width: @width-large) {
     width: 1020px;
   }

--- a/views/make-templates/make-front-page.html
+++ b/views/make-templates/make-front-page.html
@@ -10,6 +10,7 @@
       {% endif %}
       <p class="author">{{ gettext("Created by @username") | localVar(make) }}</a>
     </div>
-    <a href="{{make.remixurl}}"><div class="make-now"></div></a>
+    <a href="{{make.remixurl}}" class="desktop-link"><div class="make-now"></div></a>
+    <a href="{{make.url}}" class="mobile-link"><div class="make-now"></div></a>
   </a>
 </article>


### PR DESCRIPTION
...n the tools /remix page

https://bugzilla.mozilla.org/show_bug.cgi?id=929229
