### PR TITLE
bug929657 - Wrong key name for Created by in /teach

### DIFF
--- a/views/make-templates/make-teach.html
+++ b/views/make-templates/make-teach.html
@@ -6,7 +6,7 @@
     <div class="make-back">
       <div class="desc">
         <h3><a class="title" href="{{make.url}}">{{make.title}}</a></h3>
-        <p class="author-date"><img class="make-avatar" src="{{make.avatar}}">{{ "Created By" | gettext }}
+        <p class="author-date"><img class="make-avatar" src="{{make.avatar}}">{{ "Created by" | gettext }}
           {% if make.username %}
             <a class="author" href="/u/{{make.username}}">@{{make.username}}</a>
           {% else %}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=929657
