### PR TITLE
csrf-token rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "helmet": "0.0.11",
     "knox": "0.8.x",
     "less-middleware": "0.1.12",
-    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.11",
+    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.12",
     "mapquest": "0.0.1",
     "markdown": "0.4.x",
     "messina": "0.1.1",

--- a/public/events/ext/js/rails.js
+++ b/public/events/ext/js/rails.js
@@ -54,7 +54,7 @@
     // Make sure that every Ajax request sends the CSRF token
     CSRFProtection: function(xhr) {
       var token = $('meta[name="csrf-token"]').attr('content');
-      if (token) xhr.setRequestHeader('X-CSRF-Token', token);
+      if (token) xhr.setRequestHeader('X-CSRF-Token', token); // express.js uses a non-standard name for csrf-token
     },
 
     // Triggers an event on an element and returns false if the event result is false

--- a/public/js/base/gallery.js
+++ b/public/js/base/gallery.js
@@ -100,7 +100,7 @@ define(['jquery', 'nunjucks', 'base/ui', 'moment', 'makeapi', 'localized', 'maso
         }
         $.post(method, {
           makeID: makeID,
-          _csrf: $("meta[name='X-CSRF-Token']").attr("content")
+          _csrf: $("meta[name='csrf-token']").attr("content")
         }, function (res) {
           var newLen = res.likes.length,
             $count = $this.parent().parent().find(".like-count"),

--- a/public/js/pages/details.js
+++ b/public/js/pages/details.js
@@ -57,7 +57,7 @@ define(['jquery', 'social', 'localized'],
 
         $.post(method, {
           makeID: makeID,
-          _csrf: $("meta[name='X-CSRF-Token']").attr("content")
+          _csrf: $("meta[name='csrf-token']").attr("content")
         }, function (res) {
           var newLen = res.likes.length;
           $likeBtn.toggleClass("icon-heart icon-heart-empty");

--- a/public/js/pages/me.js
+++ b/public/js/pages/me.js
@@ -58,7 +58,7 @@ define(['jquery', 'uri', 'base/ui', 'localized', 'masonry'],
         if (window.confirm(localized.get("Are you sure you want to delete this make?"))) {
           $.post("/remove", {
             makeID: makeID,
-            _csrf: $("meta[name='X-CSRF-Token']").attr("content")
+            _csrf: $("meta[name='csrf-token']").attr("content")
           }, function (res) {
             if (res.deletedAt) {
               if (!inApp) {

--- a/public/js/user/new.js
+++ b/public/js/user/new.js
@@ -5,7 +5,7 @@ define(['jquery', 'sso-ux'],
     var $mailSignUp = $('#bsd');
     var $usernameInput = $("#claim-input");
     var $errorContainer = $("#error-container");
-    var csrf = $("meta[name='X-CSRF-Token']").attr("content");
+    var csrf = $("meta[name='csrf-token']").attr("content");
     var email = $("meta[name='persona-email']").attr("content");
     var AUDIENCE = $("meta[name='audience']").attr("content");
     var loginURL = $("meta[name='login-url']").attr("content");
@@ -40,7 +40,7 @@ define(['jquery', 'sso-ux'],
         type: "POST",
         url: loginURL + "/user",
         headers: {
-          "X-CSRF-Token": csrf
+          "X-CSRF-Token": csrf // express.js uses a non-standard name for csrf-token
         },
         dataType: "json",
         data: {

--- a/views/details.html
+++ b/views/details.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="X-CSRF-Token" content="{{ csrf }}">
+  <meta name="csrf-token" content="{{ csrf }}">
   <link rel="stylesheet" href="/bower/font-awesome/css/font-awesome.css">
   <link media="screen" rel="stylesheet" href="/css/style.css">
   <link media="screen" rel="stylesheet" href="/css/make-details.css">

--- a/views/layout.html
+++ b/views/layout.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="X-CSRF-Token" content="{{ csrf }}">
+  <meta name="csrf-token" content="{{ csrf }}">
   <meta name="login-url" content="{{ loginAPI }}">
   <meta name="persona-email" content="{{ email }}">
   <meta name="maker-id" content="{{ makerID }}">


### PR DESCRIPTION
switch from "X-CSRF-Token" as meta name to the validation-passing "csrf-token"

https://bugzilla.mozilla.org/show_bug.cgi?id=930166
