### PR TITLE
[bug 904187] Link to return to /events from Event Details

### DIFF
--- a/locale/en_US/webmaker.org.json
+++ b/locale/en_US/webmaker.org.json
@@ -119,6 +119,7 @@
   "eventDesc": "We've got guides to help you plan. What are you in the mood to try?",
   "eventHeader": "Want to make the web with others?",
   "Events Desc": "Find an event near you or host your own.",
+  "EventsDetailsBackToEvents": "Back to Events",
   "Events": "Events",
   "Expand your network.": "Expand your network.",
   "Explore our mentoring program": "Explore our mentoring program",

--- a/public/css/events.less
+++ b/public/css/events.less
@@ -89,3 +89,17 @@ body#events {
         }
     }
 }
+
+#back-to-events a {
+  &:before {
+    content: '◀ ';
+  }
+  &.RTL {
+    &:before {
+      content: '';
+    }
+    &:after {
+      content: ' ▶';
+    }
+  }
+}

--- a/views/events/details.html
+++ b/views/events/details.html
@@ -9,6 +9,9 @@
 
   <div class="ui-wrapper ui-body">
     <div id="details-pane" class="ui-section">
+      <div id="back-to-events">
+        <a class="{% if localeInfo.direction == 'rtl' %}RTL{% endif %}" href="/{{localeInfo.lang}}/events">{{ gettext("EventsDetailsBackToEvents") }}</a>
+      </div>
       <div class="gallery-sidebar">
         {% if event.picture %}
          <span class="show">


### PR DESCRIPTION
- https://bugzilla.mozilla.org/show_bug.cgi?id=904187
- Currently a big fugly but there is another bug for giving event details some UI loving
- :shipit: 
