### PR TITLE
bug949622 - Display what locale version/date is being used in healthcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "webmaker-download-locales": "0.1.2",
     "webmaker-locale-mapping": "latest",
     "webmaker-i18n": "0.3.15",
+    "webmaker-translation-stats": "0.0.1",
     "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.18",
     "web-literacy-client": "1.1.1",
     "webmaker-postalservice": "https://github.com/mozilla/node-webmaker-postalservice/tarball/v0.2.6"

--- a/routes/api/healthcheck.js
+++ b/routes/api/healthcheck.js
@@ -1,8 +1,19 @@
 var version = require("../../package").version;
+var wts = require("webmaker-translation-stats");
+var i18n = require("webmaker-i18n");
+var path = require("path");
 
 module.exports = function (req, res) {
-  res.send({
+  var healthcheckObject = {
     "http": "okay",
     "version": version
+  };
+  wts(i18n.getSupportLanguages(), path.join(__dirname, "../../locale"), function (err, data) {
+    if (err) {
+      healthcheckObject.locales = err.toString();
+    } else {
+      healthcheckObject.locales = data;
+    }
+    res.send(healthcheckObject);
   });
 };


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=949622
