### PR TITLE
Bug 996694: Adds rem base to document root

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -1,3 +1,11 @@
+html {
+  font-size: 62.5%;
+}
+
+html, body {
+  font-size: 1.6rem;
+}
+
 // Font awesome
 @import "../bower_components/font-awesome/less/font-awesome";
 @FontAwesomePath: "/bower_components/font-awesome/font";


### PR DESCRIPTION
(from [[996694](https://bugzilla.mozilla.org/show_bug.cgi?id=996694)])
Our document root font size is 16px, which is just where I strongly believe it is. The thing is, we can set the document root to 10px, then overwrite it to 16px by using 1.6rem. This makes rem calculation really easy to do, but doesn't change any existing measurements. Jonathan Snook lays it out nicely [here](http://snook.ca/archives/html_and_css/font-size-with-rem)

From there, we can use a mix of rems and ems in future components, which Chris Coyier explains [here](http://css-tricks.com/rems-ems/) because he invaded my brain for this one.
