### PR TITLE
Bug 947364: Adds overflow ellipsis for filter drop-down

### DIFF
--- a/less/ui.less
+++ b/less/ui.less
@@ -594,7 +594,10 @@ button i.icon-angle-right {
 
 .ui-selected {
   display: inline-block;
+  overflow: hidden;
   padding: 0 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ui-select-menu {
@@ -630,6 +633,11 @@ button i.icon-angle-right {
         background: @lightgrey;
       }
     }
+  }
+  li {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 

--- a/public/js/base/ui.js
+++ b/public/js/base/ui.js
@@ -24,12 +24,14 @@ define(["jquery", "text!html/ui-fragments.html"], function ($, _fragments) {
     $options.each(function (i, option) {
       var val = $(option).val(),
         html = $(option).text(),
+        title = $(option).attr("title"),
         $newLi = $li.clone();
       $newLi.attr("data-value", val);
       $newLi.html(html);
+      $newLi.attr("title", title);
       if ($(option).attr("selected")) {
         $newLi.attr("data-selected", true);
-        $selectedEl.html(html);
+        $selectedEl.html(html).attr("title", title);
       }
       $newLi.click(function () {
         $menu.find("[data-selected]").removeAttr("data-selected");

--- a/views/macros.html
+++ b/views/macros.html
@@ -12,7 +12,7 @@
           <label for="search-filter"><span class="icon-th"></span> {{ gettext("Filter the gallery") }}</label>
           <select id="search-filter">
             {% for option in options %}
-              <option value="{{ option.value | safe }}"{% if (option.default) %} selected{% endif %}>{{ option.title | safe }}</option>
+              <option value="{{ option.value | safe }}"{% if (option.default) %} selected{% endif %} title="{{ option.title | safe }}">{{ option.title | safe }}</option>
             {% endfor %}
           </select>
         </div>


### PR DESCRIPTION
([Bug 947364](https://bugzilla.mozilla.org/show_bug.cgi?id=947364))

Before:
![Filter view: before](https://dl.dropboxusercontent.com/spa/49xeskca52abzlc/b44e0nwk.png)

After:
![Filter view: after](http://snaps.akibraun.com/ytst7.png)

I'm not totally certain this is the ideal solution, but it's definitely an easy-to-do solution for right now.
