### PR TITLE
Claim Codez

### DIFF
--- a/less/badges.less
+++ b/less/badges.less
@@ -67,6 +67,15 @@
     }
   }
 
+  .icon-question-sign {
+    color: fade(@white, 60%);
+    cursor: pointer;
+    &:hover {
+    color: @white;
+    text-decoration: none;
+    }
+  }
+
   li {
     line-height: 1.6;
   }

--- a/views/badge-detail.html
+++ b/views/badge-detail.html
@@ -55,7 +55,9 @@
               <textarea class="form-control" name="evidence" placeholder="{{ gettext("BadgesIncludeLinks") }}" required></textarea>
             </div>
             <div class="form-inline">
-              <label for="claimcode">{{ gettext("HaveClaimCode") }}</label><a href="https://badges.mozilla.org" target="_blank">{{ gettext("Submit with a claim code here") }}</a><!--  <input class="form-control" name="claimcode" placeholder="Enter it here"> -->
+              <label for="claimcode">{{ gettext("HaveClaimCode") }}</label>
+              <a href="https://badgekit.org/help" target="_blank" class="icon-question-sign"></a>
+              <input class="form-control" name="claimcode" placeholder="e.g. 1234Z764HGZIHBHZ">
               <button name="submit" class="btn btn-primary btn-lg pull-right">{{ gettext("Submit") }}</button>
             </div>
           </form>


### PR DESCRIPTION
Adds an input box to the apply now form for claim codes, the help icon currently links to the help page on badgekit.org... this can be changed to something more `useful`
You can view this on `localhost:7777/badges` and clicking the apply now button
