### PR TITLE
Bug 1038163 - Remove second 'Tools' link in subnav

### DIFF
--- a/public/js/angular/services.js
+++ b/public/js/angular/services.js
@@ -61,12 +61,6 @@ angular
               pushState: true,
               pages: [
                 {
-                  id: 'tools',
-                  title: 'Tools',
-                  url: 'tools',
-                  pushState: true
-                },
-                {
                   id: 'popcorn',
                   icon: 'popcorn-icon',
                   title: 'Popcorn Maker',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1038163
