### PR TITLE
Fixes Bug 1032223 - GA tracking for email sign-up

### DIFF
--- a/public/views/partials/footer.html
+++ b/public/views/partials/footer.html
@@ -24,7 +24,7 @@
     </ul>
     <div class="row">
       <div class="col-md-4 col-md-offset-4 text-left">
-        <form name="emailForm" action="https://sendto.mozilla.org/page/s/webmaker" method="post" novalidate>
+        <form name="emailForm" action="https://sendto.webmaker.org/page/s/webmaker" method="post" novalidate>
           <div class="input-group">
             <span class="input-group-addon"><span class="fa fa-envelope"></span></span>
             <input class="form-control" type="email" ng-model="emailUpdates" name="email" autocomplete="off"  required placeholder="{{ 'Sign up for email updates' | i18n }}" >


### PR DESCRIPTION
The BSD pages now have a sendto.webmaker.org alias, which means we can track them under the same GA Profile as webmaker and count these email sign-ups along with other conversions.
