### PR TITLE
Template spelling was corrected in the 277th line.

### DIFF
--- a/locale/en_US/webmaker.org.json
+++ b/locale/en_US/webmaker.org.json
@@ -274,7 +274,7 @@
   "signup-list-intro": "What does Webmaker offer you?",
   "signup-list-1": "Use Webmaker's online <a href=\"/{{lang}}/tools\">tools</a> to create your own content",
   "signup-list-2": "Find and attend <a href=\"/{{lang}}/tools\">events</a> near you",
-  "signup-list-3": "Use Webmaker-vetted teaching <a href=\"/{{lang}}/resources\">resources</a> and tempaltes",
+  "signup-list-3": "Use Webmaker-vetted teaching <a href=\"/{{lang}}/resources\">resources</a> and templates",
   "signup-list-4": "Earn <a href=\"/{{lang}}/badges/webmaker-super-mentor\">badges</a> for your web literacy skills <span class=\"green-text\">Needs a Webmaker account</span>",
   "signup-list-5": "Save and publish with Webmaker tools <span class=\"green-text\">Needs a Webmaker account</span>",
   "signup-list-6": "Create and publish an event <span class=\"green-text\">Needs a Webmaker account</span>",


### PR DESCRIPTION
In the 277th line, their was a spelling error of "Template". It was written as "Tempaltes".
