### PR TITLE
Fixes bug1049456 optimizely in angular template

### DIFF
--- a/views/index-angular.html
+++ b/views/index-angular.html
@@ -3,7 +3,7 @@
 
 <html lang="{{lang}}" dir="{{direction}}" xmlns:ng="http://angularjs.org" ng-app="webmakerApp" id="ng-app">
   <head>
-
+    <script src="//cdn.optimizely.com/js/206878104.js"></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title ng-bind-html="title | i18n"></title>


### PR DESCRIPTION
Optimizely strongly recommends this goes in the head, otherwise you can get content flashing of experiment variations.
