### PR TITLE
Make MakeLists available through /gallery

### DIFF
--- a/app.js
+++ b/app.js
@@ -364,6 +364,11 @@ app.get("/gallery", routes.gallery({
   prefix: "p"
 }));
 
+app.get("/gallery/list/:list", routes.gallery({
+  layout: "index",
+  prefix: "p"
+}));
+
 app.get("/editor", middleware.checkAdmin, routes.gallery({
   page: "editor"
 }));

--- a/routes/gallery.js
+++ b/routes/gallery.js
@@ -49,14 +49,26 @@ module.exports = function (options) {
     var stickyLimit = options.limit ? options.limit * 2 : DEFAULT_STICKY_LIMIT;
     var totalHitCount = [];
 
+    // if a make list (gallery) id is specified, use that as the primary list of makes
+    var makeListID = req.params.list;
+
     function getMakes(options, callback) {
       make.setLang(req.localeInfo.momentLang);
-      make
-        .find(options)
-        .process(function (err, data, totalHits) {
-          totalHitCount.push(totalHits);
-          callback(err, data);
-        }, req.session.user ? req.session.user.id : '');
+
+      if (makeListID) {
+        make
+          .getList(makeListID, function (err, data, totalHits) {
+            totalHitCount.push(totalHits);
+            callback(err, data);
+          });
+      } else {
+        make
+          .find(options)
+          .process(function (err, data, totalHits) {
+            totalHitCount.push(totalHits);
+            callback(err, data);
+          }, req.session.user ? req.session.user.id : '');
+      }
     }
 
     var stickyOptions = {


### PR DESCRIPTION
1. Added routing for /gallery/list/:list in app.js.
2. Use different makeapi-client search function for lists (only) in gallery.js.
