### PR TITLE
Issue #1066 - Add missing strings

### DIFF
--- a/locale/en_US/webmaker.org.json
+++ b/locale/en_US/webmaker.org.json
@@ -323,6 +323,8 @@
   "BadgeNotFoundDesc": "Sorry, looks like that badge doesn't exist in our system.",
   "NoBadgeHere": "No badge here!",
   "Thanks": "Thanks",
+  "Make successfully reported": "Make successfully reported",
+  "Search gallery": "Search gallery",
   "IssuedBadgeSuccess": "Your badge was issued successfully.",
   "BadgesIssuedBy": "Issued by:",
   "ViewOnProfile": "View on your profile",

--- a/views/badge-detail.html
+++ b/views/badge-detail.html
@@ -69,7 +69,7 @@
             <div class="form-group">
               <label for="evidence">{{ gettext("BadgesEvidenceLabel") }}</label>
               <textarea class="form-control" name="evidence" placeholder="{{ gettext("BadgesIncludeLinks") }}" required>
-                {%- if application.evidence.length >= 1 -%} 
+                {%- if application.evidence.length >= 1 -%}
                   {{ application.evidence[0].reflection }}
                 {%- endif -%}
               </textarea>
@@ -78,7 +78,7 @@
             <div class="form-group">
               <label for="city">{{ gettext("BadgesCityLabel") }}</label>
               <textarea class="form-control" name="city" placeholder="{{ gettext("BadgesExampleCity") }}" required>
-                {%- if application.evidence.length >= 2 -%} 
+                {%- if application.evidence.length >= 2 -%}
                   {{ application.evidence[1].reflection | replace("Hive City: ", "")}}
                 {%- endif -%}
               </textarea>
@@ -102,7 +102,7 @@
       <div id="issue-badge-success" class="panel panel-info panel-badges hidden">
         <div class="panel-body">
           <h2>{{ gettext("Thanks") }}</h2>
-          <p>{{ gettext("Your badge was issued successfully.") }}</p>
+          <p>{{ gettext("IssuedBadgeSuccess") }}</p>
         </div>
       </div>
 


### PR DESCRIPTION
There are few missing strings which causes grunt validate to complain
This patch making sure we don't have any missing strings in the locale file.

To test this simply run `node app.js` and visit badge page and browse around to see
if we have any weird strings being display.