### PR TITLE
Integrate Angular i18n finder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -206,7 +206,7 @@ module.exports = function (grunt) {
   grunt.registerTask('default', ['clean', 'jshint', 'jsonlint', 'imagemin']);
 
   // Verify code (Read only)
-  grunt.registerTask('validate', ['jsbeautifier:verify', 'jshint', 'gettext_finder', 'jsonlint']);
+  grunt.registerTask('validate', ['jsbeautifier:verify', 'jshint', 'gettext_finder', 'jsonlint', 'angular_i18n_finder']);
 
   // Run through all pages and test for JS errors
   // * Requires global install of PhantomJS *

--- a/gtf-ignored-keys.json
+++ b/gtf-ignored-keys.json
@@ -1,5 +1,5 @@
 [ "advanced", "beginner", "intermediate", "Webpages with Thimble", "Are you sure you want to delete this make?",
   "Confirm", "Created by", "created", "Updated", "updated", "unpublished", "Resources", "Resource Templates",
   "Remixes with X-Ray Goggles", "NoEventsFound", "Multimedia with Popcorn", "make", "Make", "Details", "Explore",
-  "DetailsShareTwitterMsg", "guide", "Info", "Did you know Webmaker is also available in", "Webmaker"
+  "DetailsShareTwitterMsg", "guide", "Info", "Did you know Webmaker is also available in", "Webmaker", "Events"
 ]

--- a/locale/en_US/appmaker.json
+++ b/locale/en_US/appmaker.json
@@ -15,6 +15,18 @@
     "message": "Mobile apps made easy",
     "description": "A pithy phrase about Appmaker"
   },
+  "students": {
+    "message": "students",
+    "description": "students"
+  },
+  "business": {
+    "message": "business",
+    "description": "business"
+  },
+  "friends": {
+    "message": "friends",
+    "description": "friends"
+  },
   "Appmaker Desc": {
     "message": "Make apps for your phone.",
     "description": "A very short explanation for what Appmaker is"
@@ -23,7 +35,7 @@
     "message": "Discover Appmaker",
     "description": "Title for Appmaker landing page"
   },
-  "Don't know where to start?": {
+  "Dont know where to start?": {
     "message": "Looking for an easy way to get started? Remix one of these templates to make your very own app.",
     "description": "Catch the imagination of users at the top of the page."
   },

--- a/package.json
+++ b/package.json
@@ -56,14 +56,15 @@
   },
   "devDependencies": {
     "colors": "0.6.2",
+    "grunt-angular-i18n-finder": "0.0.6",
+    "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-imagemin": "0.3.0",
     "grunt-contrib-jshint": "0.7.1",
-    "grunt-gettext-finder": "0.0.2",
-    "grunt-jsbeautifier": "0.2.2",
-    "grunt-shell": "0.6.1",
-    "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-express-server": "^0.4.13",
-    "grunt-jsonlint": "^1.0.4"
+    "grunt-gettext-finder": "0.0.2",
+    "grunt-jsbeautifier": "0.2.2",
+    "grunt-jsonlint": "^1.0.4",
+    "grunt-shell": "0.6.1"
   }
 }

--- a/public/views/appmaker.html
+++ b/public/views/appmaker.html
@@ -3,7 +3,7 @@
     <carousel interval="5000">
       <slide class="slide" ng-repeat="audience in audiences" active="slide.active">
         <div class="container text-center">
-          <img ng-src="{{audience.image}}" alt="{{audience.title | i18n}}">{{setActiveSlide(slide.active, $index)}}
+          <img ng-src="{{audience.image}}" alt="{{ audience.title | i18n }}">{{setActiveSlide(slide.active, $index)}}
         </div>
       </slide>
       <div id="front-phone-container">
@@ -13,24 +13,24 @@
       </div>
     </carousel>
     <div class="container text-center">
-      <h1><span bind-unsafe-html="'Make an app for your...' | i18n">{{'Make an app for your...' | i18n}}</span>.</h1>
-      <p class="lead" id="sub-heading">{{'Appmaker Description' | i18n}}</p>
+      <h1><span bind-unsafe-html="'Make an app for your...' | i18n">{{ 'Make an app for your...' | i18n }}</span>.</h1>
+      <p class="lead" id="sub-heading">{{ 'Appmaker Description' | i18n }}</p>
       <p>
-        <a href="#starter-apps" class="btn btn-success btn-lg">{{'Pick a template' | i18n}}</a>
-        <a href="//apps.webmaker.org/{{lang}}/designer" class="btn btn-info btn-lg">{{'Start from scratch' | i18n}}</a>
+        <a href="#starter-apps" class="btn btn-success btn-lg">{{ 'Pick a template' | i18n }}</a>
+        <a href="//apps.webmaker.org/{{lang}}/designer" class="btn btn-info btn-lg">{{ 'Start from scratch' | i18n }}</a>
       </p>
     </div>
   </section>
   <section name="starter-apps" id="starter-apps">
     <div class="container">
-      <p class="lead text-center">{{'Don\'t know where to start?' | i18n}}</p>
+      <p class="lead text-center">{{ 'Dont know where to start?' | i18n }}</p>
       <div class="row">
         <div class="col-sm-4" ng-repeat="make in makes">
           <div class="make sample-make">
             <div class="thumbnail-wrapper" ng-style="{'background-image':'url('+ make.image + ')'}"></div>
             <div class="caption">
-              <h3>{{make.title | i18n}}</h3>
-              <p>{{(make.title + ' Description') | i18n}}</p>
+              <h3>{{ make.title | i18n }}</h3>
+              <p>{{ (make.title + ' Description') | i18n }}</p>
               <p>
                 <a href="{{make.remixUrl}}" class="btn btn-primary" role="button">
                   <span class="fa fa-code-fork"></span> Remix
@@ -48,39 +48,39 @@
       </div>
     </div>
     <div id="gallery-actions">
-      <a class="load-more" href="/{{lang}}/gallery/list/53fe24bc21d4817b6c000aad">{{'See more' | i18n}} <span class="icon-angle-down"></span></a>
+      <a class="load-more" href="/{{lang}}/gallery/list/53fe24bc21d4817b6c000aad">{{ 'See more' | i18n }} <span class="icon-angle-down"></span></a>
     </div>
   </section>
   <section>
     <div class="container">
       <div class="row">
         <div class="col-sm-4 text-center">
-          <img class="maker-party-logo" src="/img/appmaker/teach.svg" alt="{{'Teach' | i18n}}">
-          <h2>{{'Teach' | i18n}}</h2>
-          <p>{{'Teach Description' | i18n}}</p>
+          <img class="maker-party-logo" src="/img/appmaker/teach.svg" alt="{{ 'Teach' | i18n }}">
+          <h2>{{ 'Teach' | i18n }}</h2>
+          <p>{{ 'Teach Description' | i18n }}</p>
           <p>
             <a href="https://jess.makes.org/thimble/MTMyMzM2ODQ0OA==/mobile-design-kit" class="btn btn-info" role="button">
-              {{'See how' | i18n}}
+              {{ 'See how' | i18n }}
             </a>
           </p>
         </div>
         <div class="col-sm-4 text-center">
-          <img class="maker-party-logo" src="/img/appmaker/contribute.svg" alt="{{'Contribute' | i18n}}">
-          <h2>{{'Contribute' | i18n}}</h2>
-          <p>{{'Contribute Description' | i18n}}</p>
+          <img class="maker-party-logo" src="/img/appmaker/contribute.svg" alt="{{ 'Contribute' | i18n }}">
+          <h2>{{ 'Contribute' | i18n }}</h2>
+          <p>{{ 'Contribute Description' | i18n }}</p>
           <p>
             <a href="//github.com/mozilla-appmaker/appmaker/wiki/How-to-Contribute" class="btn btn-info" role="button">
-              {{'Get started' | i18n}}
+              {{ 'Get started' | i18n }}
             </a>
           </p>
         </div>
         <div class="col-sm-4 text-center">
-          <img class="maker-party-logo" src="/img/appmaker/imagine.svg" alt="{{'Imagine' | i18n}}">
-          <h2>{{'Imagine' | i18n}}</h2>
-          <p>{{'Imagine Description' | i18n}}</p>
+          <img class="maker-party-logo" src="/img/appmaker/imagine.svg" alt="{{ 'Imagine' | i18n }}">
+          <h2>{{ 'Imagine' | i18n }}</h2>
+          <p>{{ 'Imagine Description' | i18n }}</p>
           <p>
             <a href="//mozilla.github.io/mobile-opportunity/" class="btn btn-info" role="button">
-              {{'Learn more' | i18n}}
+              {{ 'Learn more' | i18n }}
             </a>
           </p>
         </div>

--- a/public/views/explore.html
+++ b/public/views/explore.html
@@ -55,30 +55,30 @@
         <div class="row">
           <div class="tool">
             <a href="https://goggles.webmaker.org/{{ lang }}">
-              <h3 class="xray-goggles">{{'X-Ray Goggles' | i18n}}</h3>
+              <h3 class="xray-goggles">{{ 'X-Ray Goggles' | i18n }}</h3>
             </a>
 
             <p>{{ 'X-Ray Desc' | i18n }}</p>
           </div>
           <div class="tool">
             <a href="https://thimble.webmaker.org/{{ lang }}">
-              <h3 class="thimble">{{'Thimble' | i18n}}</h3>
+              <h3 class="thimble">{{ 'Thimble' | i18n }}</h3>
             </a>
 
-            <p>{{'Thimble Desc' | i18n }}</p>
+            <p>{{ 'Thimble Desc' | i18n }}</p>
           </div>
           <div class="tool">
             <a href="https://popcorn.webmaker.org/{{ lang }}">
-              <h3 class="popcorn-maker">{{'Popcorn Maker'}}</h3>
+              <h3 class="popcorn-maker">{{ 'Popcorn Maker'}}</h3>
             </a>
 
-            <p>{{'Popcorn Maker Desc'| i18n}}</p>
+            <p>{{ 'Popcorn Maker Desc'| i18n }}</p>
           </div>
           <div class="tool">
             <a href="https://apps.webmaker.org/{{ lang }}/designer">
-              <h3 class="appmaker">{{'Appmaker' | i18n}}</h3>
+              <h3 class="appmaker">{{ 'Appmaker' | i18n }}</h3>
             </a>
-            <p>{{'Appmaker Desc' | i18n}}</p>
+            <p>{{ 'Appmaker Desc' | i18n }}</p>
           </div>
         </div>
       </div>
@@ -105,7 +105,7 @@
   </section>
 
   <section id="front-page-contribute" class="container">
-    <h2 class="text-primary">{{'Contribute to Webmaker' | i18n }}</h2>
+    <h2 class="text-primary">{{ 'Contribute to Webmaker' | i18n }}</h2>
 
     <p>
       <span bind-unsafe-html="'Contribute subsection copy' | i18n"></span>
@@ -131,7 +131,7 @@
 
   <section id="front-page-where-to-start">
     <div class="container">
-      <h2 class="text-primary">{{'Footer header' | i18n}}</h2>
+      <h2 class="text-primary">{{ 'Footer header' | i18n }}</h2>
 
       <p bind-unsafe-html="'Footer copy' | i18n"></p>
     </div>

--- a/public/views/tools.html
+++ b/public/views/tools.html
@@ -17,7 +17,7 @@
             <ul class="list list-inset">
               <li>{{ 'a custom homepage for the New York Times' | i18n }}</li>
               <li>{{ 'an alternate version of a controversial webpage' | i18n }}</li>
-              <li>{{ "a funny remix of your best friend's favorite site" | i18n }}</li>
+              <li>{{ 'a funny remix of your best friend's favorite site' | i18n }}</li>
               <li>{{ 'and more!' | i18n }}</li>
             </ul>
             <div class="text-center">
@@ -38,18 +38,18 @@
               <p class="lead">{{ 'Webmaking made easy' | i18n }}</p>
               </a>
             </hgroup>
-            <p>{{ "toolsThimbleDesc" | i18n }}</p>
-            <h4>{{ "You can build:" | i18n }}</h4>
+            <p>{{ 'toolsThimbleDesc' | i18n }}</p>
+            <h4>{{ 'You can build:' | i18n }}</h4>
             <ul class="list list-inset">
-              <li>{{ "a personalized greeting card" | i18n }}</li>
-              <li>{{ "an online poster for your favorite movie" | i18n }}</li>
-              <li>{{ "a hilarious meme" | i18n }}</li>
-              <li>{{ "and more!" | i18n }}</li>
+              <li>{{ 'a personalized greeting card' | i18n }}</li>
+              <li>{{ 'an online poster for your favorite movie' | i18n }}</li>
+              <li>{{ 'a hilarious meme' | i18n }}</li>
+              <li>{{ 'and more!' | i18n }}</li>
             </ul>
             <div class="text-center">
-              <h3>{{ "Get started" | i18n }}</h3>
+              <h3>{{ 'Get started' | i18n }}</h3>
                 <p><a href="https://thimble.webmaker.org/{{lang}}" class="btn btn-lg btn-info">
-                  {{ "Start from scratch" | i18n }}
+                  {{ 'Start from scratch' | i18n }}
                 </a></p>
                 <p><a href="/{{lang}}/explore" class="btn btn-lg btn-success"><span class="fa fa-code-fork"></span> {{ 'Remix a make' | i18n }}</a></p>
             </div>
@@ -62,22 +62,22 @@
             <hgroup class="text-center">
               <a href="https://popcorn.webmaker.org/{{lang}}/editor/">
               <p><img class="tools-logo" src="/img/icon-tools-popcorn-2x.png" alt="{{ 'Popcorn Maker' | i18n }}"></p>
-              <h2 class="text-primary">{{ "Popcorn Maker" | i18n }}</h2>
-              <p class="lead">{{ "Supercharge web video" | i18n }}</p>
+              <h2 class="text-primary">{{ 'Popcorn Maker' | i18n }}</h2>
+              <p class="lead">{{ 'Supercharge web video' | i18n }}</p>
               </a>
             </hgroup>
-            <p>{{ "toolsPMDesc" | i18n }}</p>
-            <h4>{{ "You can build:" | i18n }}</h4>
+            <p>{{ 'toolsPMDesc' | i18n }}</p>
+            <h4>{{ 'You can build:' | i18n }}</h4>
             <ul class="list list-inset">
-              <li>{{ "an animated gif with sound" | i18n }}</li>
-              <li>{{ "a documentary with dynamic links" | i18n }}</li>
-              <li>{{ "vdo-profile" | i18n }}</li>
-              <li>{{ "and more!" | i18n }}</li>
+              <li>{{ 'an animated gif with sound' | i18n }}</li>
+              <li>{{ 'a documentary with dynamic links' | i18n }}</li>
+              <li>{{ 'vdo-profile' | i18n }}</li>
+              <li>{{ 'and more!' | i18n }}</li>
             </ul>
             <div class="text-center">
-              <h3>{{ "Get started" | i18n }}</h3>
+              <h3>{{ 'Get started' | i18n }}</h3>
               <p><a href="https://popcorn.webmaker.org/{{lang}}/editor/" class="btn btn-info btn-lg">
-                {{ "Start from scratch" | i18n }} <span class="fa fa-angle-{{direction}}"></span></a></p>
+                {{ 'Start from scratch' | i18n }} <span class="fa fa-angle-{{direction}}"></span></a></p>
               <p><a href="/{{lang}}/explore" class="btn btn-success btn-lg">
                 <span class="fa fa-code-fork"></span> {{ 'Remix a make' | i18n }}</a></p>
             </div>
@@ -90,22 +90,22 @@
             <hgroup class="text-center">
               <a href="https://apps.webmaker.org/en-US/designer">
               <p><img class="tools-logo" src="/img/logo_brickphone_phone_only.png" alt="{{ 'Popcorn Maker' | i18n }}"></p>
-              <h2 class="text-primary">{{ "Appmaker" | i18n }}</h2>
-              <p class="lead">{{ "Mobile apps made easy" | i18n }}</p>
+              <h2 class="text-primary">{{ 'Appmaker' | i18n }}</h2>
+              <p class="lead">{{ 'Mobile apps made easy' | i18n }}</p>
               </a>
             </hgroup>
             <p>{{ 'Appmaker Description' | i18n }}</p>
             <h4>{{ 'You can build:' | i18n }}</h4>
             <ul class="list list-inset">
-              <li>{{ "an app to chat with your friends" | i18n }}</li>
-              <li>{{ "a music-making app" | i18n }}</li>
-              <li>{{ "a personal goal tracker" | i18n }}</li>
-              <li>{{ "and more!" | i18n }}</li>
+              <li>{{ 'an app to chat with your friends' | i18n }}</li>
+              <li>{{ 'a music-making app' | i18n }}</li>
+              <li>{{ 'a personal goal tracker' | i18n }}</li>
+              <li>{{ 'and more!' | i18n }}</li>
             </ul>
             <div class="text-center">
-              <h3>{{ "Get started" | i18n }}</h3>
+              <h3>{{ 'Get started' | i18n }}</h3>
               <p><a href="https://apps.webmaker.org/en-US/designer" class="btn btn-info btn-lg">
-                {{ "Start from scratch" | i18n }}</a></p>
+                {{ 'Start from scratch' | i18n }}</a></p>
               <p><a href="/{{lang}}/appmaker" class="btn btn-success btn-lg">
                 <span class="fa fa-code-fork"></span> {{ 'Remix a make' | i18n }}</a></p>
             </div>


### PR DESCRIPTION
This patch add grunt angular i18n finder and making sure most of it using the right format
This way we will be able to run the grunt validate and find any missing or unused keys

To test this simply run `npm install` then run `grunt validate`

Please note that there are many unused strings that next PR will cover the fix