### PR TITLE
Re-instrument conversion tracking (for MWC)

### DIFF
--- a/views/app.html
+++ b/views/app.html
@@ -64,7 +64,7 @@
         <button id="get-app" class="btn btn-neue desktop-only">
           {{ gettext("Get App") }}</span>
         </button>
-        <a href="http://mzl.la/installwm" class="btn btn-neue mobile-only">
+        <a href="http://mzl.la/installwm" class="btn btn-neue mobile-only download-app-btn">
           {{ gettext("Download Webmaker")}}
         </a>
         <div id="sms-form" class="hidden">
@@ -109,7 +109,7 @@
       <p class="lead">{{ gettext("Meant to be seen") }}</p>
     </div>
   </div>
-  <div class="bottom-download-btn mobile-only nudge text-center">
+  <div class="bottom-download-btn mobile-only nudge text-center download-app-btn">
     <a href="http://mzl.la/installwm" class="btn btn-neue">
       {{ gettext("Download Webmaker")}}
     </a>


### PR DESCRIPTION
The class `download-app-btn` was removed from the download buttons after our metrics QA.

This class was [being used here](https://github.com/mozilla/webmaker.org/blob/master/public/js/pages/install-app.js#L101) to track clicks on this button and send conversion goals to GA.